### PR TITLE
chore: prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and per-release binaries and notes are published from git tags by GoReleaser.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-05
+
 ### Added
 
 - Pipe support: `jws sign`, `jws verify`, `jws parse`, and `jwe encrypt`/`decrypt`
@@ -99,6 +101,7 @@ defaults explicit, and adds a thorough test suite.
 Pre-review development releases (0.0.1 through 0.0.8). See the git history and
 the [release page](https://github.com/nao1215/jose/releases) for details.
 
-[Unreleased]: https://github.com/nao1215/jose/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/nao1215/jose/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/nao1215/jose/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/nao1215/jose/compare/v0.0.8...v0.1.0
 [0.0.8]: https://github.com/nao1215/jose/releases/tag/v0.0.8


### PR DESCRIPTION
## Summary

Promotes the current Unreleased changelog entries to v0.2.0 ahead of tagging.

Since v0.1.0 the project gained:

- Migration from jwx v2 to jwx v4 (#97), which raises the minimum to Go 1.26.
- jwa output filtering, JWS inline-token/typo handling, jwk option validation, and pipe support (#98).

These are backward-compatible additions and fixes, so this is a minor version bump (v0.1.0 -> v0.2.0).

## Changes

- Move the `[Unreleased]` block to `[0.2.0] - 2026-06-05`.
- Update the changelog compare links.