### PR TITLE
chore: prepare v0.2.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,4 +29,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,11 +24,11 @@ archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:
@@ -44,11 +44,3 @@ nfpms:
       - deb
       - rpm
       - apk
-brews:
-  - name: jose
-    description: jose - CLI tool for JOSE (JSON Object Signing and Encryption)
-    license: MIT
-    repository:
-      owner: nao1215
-      name: homebrew-tap
-      token: "{{ .Env.TAP_GITHUB_TOKEN }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and per-release binaries and notes are published from git tags by GoReleaser.
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-06
+
+### Fixed
+
+- The release workflow now completes. GoReleaser was failing on the Homebrew
+  tap publish step (`401 Bad credentials` against `nao1215/homebrew-tap`), which
+  aborted the whole release. Homebrew distribution is dropped for now so tagged
+  releases publish their binaries, archives, and packages again.
+
+### Changed
+
+- Modernized the GoReleaser config to drop deprecated keys: `snapshot`
+  uses `version_template`, the Windows archive override uses `formats: [zip]`,
+  and the deprecated `brews` section was removed.
+- Bumped dependencies: `github.com/go-playground/validator/v10` 10.30.1 → 10.30.3,
+  `github.com/charmbracelet/log` 0.4.2 → 1.0.0, and the
+  `goreleaser/goreleaser-action` GitHub Action 6 → 7.
+
 ## [0.2.0] - 2026-06-05
 
 ### Added
@@ -101,7 +119,8 @@ defaults explicit, and adds a thorough test suite.
 Pre-review development releases (0.0.1 through 0.0.8). See the git history and
 the [release page](https://github.com/nao1215/jose/releases) for details.
 
-[Unreleased]: https://github.com/nao1215/jose/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/nao1215/jose/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/nao1215/jose/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/nao1215/jose/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/nao1215/jose/compare/v0.0.8...v0.1.0
 [0.0.8]: https://github.com/nao1215/jose/releases/tag/v0.0.8


### PR DESCRIPTION
## Why

The Release workflow has been failing for both v0.1.0 and v0.2.0. GoReleaser aborted at the Homebrew tap publish step:

```
error checking for default branch projectID=nao1215/homebrew-tap statusCode=401 error=GET https://api.github.com/repos/nao1215/homebrew-tap: 401 Bad credentials
```

The `TAP_GITHUB_TOKEN` secret (last set 2024-05-01) is an expired PAT, so the whole release failed even though the binaries built fine.

## What

- **Drop the Homebrew tap publish step** (`brews`) so tagged releases publish their binaries, archives, and nfpm packages again. Homebrew distribution can be re-added later once a valid tap token is provisioned. Also removed the now-unused `TAP_GITHUB_TOKEN` env from `release.yml`.
- **Modernize the GoReleaser config** to drop deprecated keys flagged in the release logs:
  - `snapshot.name_template` → `snapshot.version_template`
  - Windows `format_overrides.format: zip` → `formats: [zip]`
  - removed the deprecated `brews` section
- **CHANGELOG**: record v0.2.1 (release fix + dependency bumps).

The dependency bumps from Dependabot (#100 validator 10.30.3, #101 charmbracelet/log 1.0.0, #102 goreleaser-action v7) were merged into main ahead of this PR and are included in this release.

After this merges, tag `v0.2.1` will be pushed to trigger a green release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released v0.2.1 with release workflow improvements and configuration optimizations.
  * Homebrew package distribution temporarily unavailable due to credential issues; availability will be restored in future releases.
  * Updated release configuration for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->