### PR TITLE
build(coverage): combine unit and self-hosted E2E coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,55 @@
+name: Coverage
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# octocov reports/diffs coverage to the Actions-artifact datastore and comments
+# on pull requests, so it needs more than the default read-only token.
+permissions:
+  contents: read
+  actions: write
+  pull-requests: write
+
+env:
+  # jwx v4 uses encoding/json/v2, gated behind this experiment on Go 1.26.
+  GOEXPERIMENT: jsonv2
+
+jobs:
+  coverage:
+    name: Coverage (unit + e2e)
+
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+
+      - name: Install atago
+        uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
+        with:
+          version: v0.2.0
+
+      # Combines unit-test coverage with self-hosted E2E coverage (E2E runs a
+      # `go build -cover` jose and collects covdata via GOCOVERDIR), then merges
+      # both into cover.out. The E2E specs are hermetic and need no services.
+      - name: Run combined unit + E2E coverage
+        run: make coverage
+
+      - uses: k1LoW/octocov-action@v1
+        with:
+          config: .octocov.yml
+          args: --report=cover.out

--- a/.github/workflows/linux_test.yml
+++ b/.github/workflows/linux_test.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           go-version-file: "go.mod"
 
-      - name: Run tests with coverage report output
-        run: go test ./... -coverprofile=coverage.out
-      - uses: k1LoW/octocov-action@v1
+      # Coverage reporting to octocov lives in the dedicated Coverage workflow
+      # (.github/workflows/coverage.yml), which reports the combined unit + E2E
+      # number. This job just runs the unit tests on Linux.
+      - name: Run unit tests
+        run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@
 cover.*
 jose
 dist
+
+# `make coverage` scratch: raw covdata (unit + e2e), the cover binary, and the
+# merged dir. The final cover.out / cover.html are the only kept artifacts.
+.coverage/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test e2e test-fuzz lint clean demo demo-pipe tools help
+.PHONY: build test coverage e2e test-fuzz lint clean demo demo-pipe tools help
 
 # jwx v4 uses encoding/json/v2, which is still gated behind GOEXPERIMENT=jsonv2
 # on Go 1.26. Export it for every go invocation in this Makefile.
@@ -20,11 +20,14 @@ build: ## Build binary
 	env GO111MODULE=on GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO_BUILD) $(GO_LDFLAGS) -o $(APP) main.go
 
 clean: ## Clean project
-	-rm -rf $(APP) cover.out cover.html
+	-rm -rf $(APP) cover.out cover.html .coverage
 
 test: ## Run unit tests with coverage (writes cover.out / cover.html)
 	env GOOS=$(GOOS) $(GO_TEST) -cover $(GO_PKGROOT) -coverprofile=cover.out
 	$(GO_TOOL) cover -html=cover.out -o cover.html
+
+coverage: ## Combine unit + self-hosted E2E coverage into cover.out / cover.html (builds a `go build -cover` jose; scratch under .coverage/, needs atago on PATH)
+	bash ./scripts/coverage.sh
 
 e2e: ## Run atago end-to-end tests against the freshly built binary
 	./e2e/run.sh

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -10,6 +10,13 @@
 # isolated ${workdir}, so no external fixtures are needed.
 #
 # Usage: e2e/run.sh [atago args...]        (e.g. e2e/run.sh --filter jws)
+#
+# Coverage mode (used by `make coverage`, NOT by `make e2e`): set COVER=1 to
+# build jose with `go build -cover` instead of a plain build, so the binary the
+# specs exercise emits Go runtime coverage. The caller must also export
+# GOCOVERDIR to a pre-created directory; atago passes the environment through to
+# the jose child process (no spec uses clear_env), so each jose invocation
+# writes its own covdata there. The DEFAULT (COVER unset) path is unchanged.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
@@ -26,8 +33,14 @@ cleanup() { rm -rf "$TMP"; }
 trap cleanup EXIT
 mkdir -p "$TMP/bin"
 
-echo "e2e: building jose (GOEXPERIMENT=jsonv2)..."
-(cd "$REPO_ROOT" && env GOEXPERIMENT=jsonv2 CGO_ENABLED=0 go build -o "$TMP/bin/jose" main.go)
+if [ "${COVER:-}" = "1" ]; then
+	echo "e2e: building coverage-instrumented jose (GOEXPERIMENT=jsonv2, -cover)..."
+	(cd "$REPO_ROOT" && env GOEXPERIMENT=jsonv2 CGO_ENABLED=0 \
+		go build -cover -covermode=atomic -coverpkg=./... -o "$TMP/bin/jose" main.go)
+else
+	echo "e2e: building jose (GOEXPERIMENT=jsonv2)..."
+	(cd "$REPO_ROOT" && env GOEXPERIMENT=jsonv2 CGO_ENABLED=0 go build -o "$TMP/bin/jose" main.go)
+fi
 
 # Put the e2e-built jose first on PATH so the specs exercise that binary.
 export PATH="$TMP/bin:$PATH"

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Combine unit-test coverage with self-hosted E2E coverage into a single
+# cover.out. Unit tests report line coverage, but they never exercise the real
+# jose binary the way an end user does; the atago E2E specs do. Go 1.20+ lets us
+# instrument a built binary (`go build -cover`) and collect its runtime coverage
+# via GOCOVERDIR, so we can merge "what the tests cover" with "what a real run
+# covers" and get one honest number.
+#
+# This is intentionally a separate, heavier target: `make test` / `make e2e`
+# stay fast and unchanged. Everything lands under .coverage/ (gitignored) except
+# the final cover.out / cover.html, which are the same artifacts `make test`
+# already produces so octocov and local tooling need no changes.
+#
+# jwx v4 uses encoding/json/v2, still gated behind GOEXPERIMENT=jsonv2 on Go
+# 1.26, so every go invocation here (build AND test) must keep it set — the
+# Makefile exports it, and we set it defensively for direct invocations too.
+set -euo pipefail
+
+export GOEXPERIMENT="${GOEXPERIMENT:-jsonv2}"
+
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+root="$(pwd)"
+cov="${root}/.coverage"
+
+rm -rf "${cov}"
+mkdir -p "${cov}/unit" "${cov}/e2e" "${cov}/merged"
+
+# 1. Unit-test coverage as raw covdata (GOCOVERDIR form) so it can be merged
+#    with the E2E covdata below. -covermode=atomic must match the binary build.
+echo ">> unit coverage -> ${cov}/unit"
+go test -count=1 -cover -covermode=atomic -coverpkg=./... ./... \
+	-args -test.gocoverdir="${cov}/unit"
+
+# 2. Self-hosted E2E via a coverage-instrumented jose. e2e/run.sh builds jose
+#    with `go build -cover` (COVER=1), puts it first on PATH, and runs the atago
+#    specs; atago passes GOCOVERDIR through to each jose child, which writes its
+#    own covdata into ${cov}/e2e.
+echo ">> e2e coverage -> ${cov}/e2e"
+COVER=1 GOCOVERDIR="${cov}/e2e" ./e2e/run.sh "$@"
+
+# 3. Merge the raw covdata and render the combined text profile + reports.
+echo ">> merging unit + e2e covdata -> cover.out"
+go tool covdata merge -i="${cov}/unit,${cov}/e2e" -o="${cov}/merged"
+go tool covdata textfmt -i="${cov}/merged" -o="${root}/cover.out"
+
+go tool cover -func=cover.out | tail -n 1
+go tool cover -html=cover.out -o cover.html
+echo ">> wrote cover.out and cover.html (unit + e2e combined)"


### PR DESCRIPTION
## What

Make jose's coverage number reflect **unit tests + self-hosted E2E** (the atago specs that run the real `jose` binary), instead of unit-only. Mirrors the pattern already used in the `atago` repo (nao1215/atago#89).

## How

- **`scripts/coverage.sh`** (new): runs unit tests as raw covdata via `GOCOVERDIR`, runs the E2E suite against a `go build -cover` jose that emits runtime covdata, then `go tool covdata merge` + `textfmt` into `cover.out` / `cover.html`. `GOEXPERIMENT=jsonv2` is preserved for both build and test (jwx v4 needs it on Go 1.26).
- **`e2e/run.sh`**: add a `COVER=1` switch that builds the coverage-instrumented binary. The default `make e2e` path is byte-for-byte unchanged and stays fast. No spec uses `clear_env`, so `GOCOVERDIR` reaches every jose child through atago and no `GOCOVERDIR not set` warning is emitted.
- **`Makefile`**: add `make coverage`, extend `make clean` to drop `.coverage`, mark the target PHONY. `make test` / `make e2e` are untouched.
- **`.gitignore`**: ignore the `.coverage/` scratch dir (only `cover.out` / `cover.html` are kept).
- **`.github/workflows/coverage.yml`** (new): dedicated job that installs Go + atago (`nao1215/setup-atago`, same pin as the E2E workflow) and feeds the combined `cover.out` to octocov. Coverage reporting to octocov is removed from `linux_test.yml` so there is a **single** octocov reporter — no badge race on `main`. The unit-test / E2E workflows keep running as before.

The README already has an octocov coverage badge at the top; it now reflects the combined number through the same datastore, so no badge change is needed.

## Result

- unit-only **82.7%** -> combined **83.0%** (local)
- 45 E2E scenarios pass under the instrumented binary
- zero `GOCOVERDIR not set` warnings

## Verified locally

- `make test` passes (unchanged)
- `make e2e` passes (unchanged, 45 scenarios)
- `make coverage` writes `cover.out` + `cover.html`, `go tool cover -func` succeeds, combined total > unit-only, no warnings