### PR TITLE
ci: bump atago to v0.13.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.5.1
+          version: v0.13.0
 
       # Combines unit-test coverage with self-hosted E2E coverage (E2E runs a
       # `go build -cover` jose and collects covdata via GOCOVERDIR), then merges

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.5.1
+          version: v0.13.0
 
       # The atago specs are shell-free (no `shell: true`), so they drive the real
       # jose binary directly on every OS. run.sh is a bash bootstrap; on Windows


### PR DESCRIPTION
## Summary

Moves the atago E2E jobs to v0.13.0, the current release.

## Changes

- Bump the `nao1215/setup-atago` version input to `v0.13.0` in the workflows that run atago.

## Design Decisions

v0.13.0 changes two contracts that can turn a previously green spec red, so this is worth noting rather than treating as a routine bump. A command killed by its timeout now fails the step unless an assert reads its result, and the spec loader rejects explicit YAML tags. The specs in this repository author no YAML tags, and any step that sets a timeout is followed by an assert on the result, so neither change applies here. CI is the check that confirms it.