### PR TITLE
chore(ci): bump atago to v0.15.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.13.0
+          version: v0.15.0
 
       # Combines unit-test coverage with self-hosted E2E coverage (E2E runs a
       # `go build -cover` jose and collects covdata via GOCOVERDIR), then merges

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.13.0
+          version: v0.15.0
 
       # The atago specs are shell-free (no `shell: true`), so they drive the real
       # jose binary directly on every OS. run.sh is a bash bootstrap; on Windows


### PR DESCRIPTION
Move the pinned atago used by this repo's workflows from v0.13.0 to v0.15.0.

Two changes in that range can turn a passing spec red:

- `changes:` now tracks symlinks, so a step that plants or retargets a link is a
  creation or a modification instead of being invisible.
- `file: exists` / `file: executable` no longer accept a directory.

Neither affects the specs in this repo (checked: no `changes:` assertion here
covers a symlink-creating step, and no `file:` assertion targets a directory).
Everything else in v0.14.0 and v0.15.0 is additive or improves failure messages.