### PR TITLE
chore(ci): bump atago to v0.16.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.15.0
+          version: v0.16.0
 
       # Combines unit-test coverage with self-hosted E2E coverage (E2E runs a
       # `go build -cover` jose and collects covdata via GOCOVERDIR), then merges

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.15.0
+          version: v0.16.0
 
       # The atago specs are shell-free (no `shell: true`), so they drive the real
       # jose binary directly on every OS. run.sh is a bash bootstrap; on Windows


### PR DESCRIPTION
Move the pinned atago used by this repo's workflows from v0.15.0 to v0.16.0.

v0.16.0 adds `changes: ignore:` and fixes failure messages that pointed at the
wrong step. Two entries could matter to a suite:

- A `pty` step killed with its program still running reports a new step name and
  message, and a failure block names the command the failing check asserts on
  rather than the scenario's last command. Only a spec that pins atago's own
  console text is affected; the specs here assert on this repo's own output.
- `--repeat` / `--retry-failed` write attempts after the first into an
  `attempt-<N>` subdirectory of `--artifacts-dir`.

Verified first on career, whose atago E2E is green on Linux and macOS with this
version.