### PR TITLE
chore(ci): bump atago to v0.17.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.16.0
+          version: v0.17.0
 
       # Combines unit-test coverage with self-hosted E2E coverage (E2E runs a
       # `go build -cover` jose and collects covdata via GOCOVERDIR), then merges

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.16.0
+          version: v0.17.0
 
       # The atago specs are shell-free (no `shell: true`), so they drive the real
       # jose binary directly on every OS. run.sh is a bash bootstrap; on Windows


### PR DESCRIPTION
Pins the E2E suites to [atago v0.17.0](https://github.com/nao1215/atago/releases/tag/v0.17.0).

That release adds a Scoop bucket for Windows installs and carries two failure-message fixes: an assertion whose observed value was empty now renders `(empty)` instead of omitting the `Actual:` section, and a run step whose output capture was cut short now names the exit code the process reached instead of reporting `failed to execute`.

No spec changes are needed — neither fix alters an assertion's verdict, only how a failure reads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated coverage and end-to-end testing workflows to use Atago v0.17.0.
  * Existing workflow triggers, permissions, and test processes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->